### PR TITLE
update GeometryDashAPI to 0.2.28

### DIFF
--- a/MIDI2GD/MIDI2GD.csproj
+++ b/MIDI2GD/MIDI2GD.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GeometryDashAPI" Version="0.2.27" />
+    <PackageReference Include="GeometryDashAPI" Version="0.2.28" />
     <PackageReference Include="Melanchall.DryWetMidi" Version="7.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
I've now released new version of GeometryDashAPI: [v0.2.28](https://github.com/Folleach/GeometryDashAPI/releases/tag/v0.2.28)

In this release @flightlex fix the bug with invalid xml characters.  
This release should fix the issue #1

Next time, feel free to write about the problems to me ^_^
I didn't know you had such a problem either...
